### PR TITLE
Download files over HTTPS.

### DIFF
--- a/udger-updater.sh
+++ b/udger-updater.sh
@@ -56,7 +56,7 @@ done
 
 VERSION_FILE=$DOWNLOAD_DIR/version
 VERSION_FILE_TMP=$DOWNLOAD_DIR/version.tmp
-SNAPSHOT_URL="http://data.udger.com/"$SUBSCRIPTION_KEY
+SNAPSHOT_URL="https://data.udger.com/"$SUBSCRIPTION_KEY
 VERSION_URL=$SNAPSHOT_URL/version
 
 echo "";


### PR DESCRIPTION
The URL contains the subscription key, which needs to be kept secret and should be sent over HTTPS.

This also provides a guarantee that no one is MitMing the download, which could be used to poison lookups.