### PR TITLE
Ignore downloaded files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+version
+udgerdb_v3[._]dat*


### PR DESCRIPTION
If you run the script to test downloads, it leaves files in main directory. Git should be configured to ignore these.