### PR TITLE
fix symlink to $DATA_FILE if $DOWNLOAD_DIR is set

### DIFF
--- a/udger-updater.sh
+++ b/udger-updater.sh
@@ -121,7 +121,7 @@ start_download(){
 
     if [[ $SHA1SUM_OUT == *$(head -n 1 "$FILENAME_SHA1")* ]]; then
         echo "Checksum ok"
-        $LN -sf "$DOWNLOAD_DIR/$BASE_FILE.$VERSION" "$DOWNLOAD_DIR/$BASE_FILE"
+        $LN -sf "$BASE_FILE.$VERSION" "$DOWNLOAD_DIR/$BASE_FILE"
         echo "Data downloaded sucesfully: $DATA_FILE"
     else
 	echo "Checksum mismatch"


### PR DESCRIPTION
This is a relative symlink which will be wrong if $DOWNLOAD_DIR is set to anything other than the default.